### PR TITLE
Add LocalStack for AWS license requirement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ test:		## Run the tests
 
 start:		## Start LocalStack
 	@echo "Starting LocalStack..."
+	@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
 	@LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) IMAGE_NAME=localstack/localstack-pro:latest-bigdata localstack start -d
 	@echo "LocalStack started successfully."
 

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ The following diagram shows the architecture that this sample application builds
 
 ## Prerequisites
 
+- A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a `LOCALSTACK_AUTH_TOKEN` to activate LocalStack.
 - [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli) with a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/)
 - [AWS CLI](https://docs.localstack.cloud/user-guide/integrations/aws-cli/) with the [`awslocal` wrapper](https://docs.localstack.cloud/user-guide/integrations/aws-cli/#localstack-aws-cli-awslocal)
 - [`make`](https://www.gnu.org/software/make/) (**optional**, but recommended for running the sample application)
@@ -64,7 +65,7 @@ No additional installation steps are required as the sample uses CloudFormation 
 
 ## Deployment
 
-Start LocalStack Pro with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
+Start LocalStack with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
 
 ```shell
 localstack auth set-token <LOCALSTACK_AUTH_TOKEN>

--- a/readme.md
+++ b/readme.md
@@ -33,8 +33,8 @@ The following diagram shows the architecture that this sample application builds
 
 ## Prerequisites
 
-- A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a `LOCALSTACK_AUTH_TOKEN` to activate LocalStack.
-- [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli) with a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/)
+- A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
+- [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli).
 - [AWS CLI](https://docs.localstack.cloud/user-guide/integrations/aws-cli/) with the [`awslocal` wrapper](https://docs.localstack.cloud/user-guide/integrations/aws-cli/#localstack-aws-cli-awslocal)
 - [`make`](https://www.gnu.org/software/make/) (**optional**, but recommended for running the sample application)
 


### PR DESCRIPTION
Fixes [DEVREL-2](https://linear.app/localstack/issue/DEVREL-1/update-repositories-in-the-github-org-localstack-samples-such-that)

## Summary
- Add LocalStack for AWS license as first prerequisite with link to pricing page
- Clarify that a license provides the `LOCALSTACK_AUTH_TOKEN` needed to activate LocalStack
- Remove "LocalStack Pro" terminology from deployment instructions