### PR TITLE
Migrate legacy LocalStack CLI to lstk, fix flaky Athena tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,16 +28,16 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install lstk
+        run: |
+          npm install -g @localstack/lstk
+          lstk setup aws
+
       - name: Start LocalStack
-        uses: LocalStack/setup-localstack@main
-        with:
-          image-tag: 'latest'
-          use-pro: 'true'
-          configuration: LS_LOG=trace
-          install-awslocal: 'true'
         env:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
-          IMAGE_NAME: 'localstack/localstack-pro:latest-bigdata'
+        run: |
+          lstk start
 
       - name: Deploy on CloudFormation
         run: |
@@ -50,7 +50,7 @@ jobs:
       - name: Show LocalStack logs
         if: always()
         run: |
-          localstack logs
+          lstk logs
 
       - name: Send a Slack notification
         if: failure() || github.event_name != 'pull_request'

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ volume/
 .idea/
 .vscode/
 __pycache__
+.lstk/lstk.log
+logs.txt

--- a/.lstk/config.toml
+++ b/.lstk/config.toml
@@ -1,0 +1,8 @@
+# lstk configuration file for this sample.
+# This app needs the "bigdata" image variant, which ships with Athena/Glue's
+# pre-installed big data dependencies (Hive metastore, Spark, etc).
+
+[[containers]]
+type = "aws"
+tag  = "latest-bigdata"
+port = "4566"

--- a/Makefile
+++ b/Makefile
@@ -11,21 +11,20 @@ usage:			## Show this help in table format
 check:			## Check if all required prerequisites are installed
 	@command -v docker > /dev/null 2>&1 || { echo "Docker is not installed. Please install Docker and try again."; exit 1; }
 	@command -v aws > /dev/null 2>&1 || { echo "AWS CLI is not installed. Please install AWS CLI and try again."; exit 1; }
-	@command -v awslocal > /dev/null 2>&1 || { echo "AWS CLI Local is not installed. Please install awslocal and try again."; exit 1; }
-	@command -v localstack > /dev/null 2>&1 || { echo "LocalStack is not installed. Please install LocalStack and try again."; exit 1; }
-	@command -v python > /dev/null 2>&1 || { echo "Python is not installed. Please install Python and try again."; exit 1; }
+	@command -v lstk > /dev/null 2>&1 || { echo "lstk is not installed. Please install lstk and try again."; exit 1; }
+	@command -v python3 > /dev/null 2>&1 || { echo "Python 3 is not installed. Please install Python 3 and try again."; exit 1; }
 	@echo "All required prerequisites are available."
 
 deploy:		## Setup the architecture
 	@echo "Deploying the architecture..."
 	@echo "Create S3 bucket and upload the CloudFormation template..."
-	awslocal s3 mb s3://covid19-lake; \
-	awslocal s3 cp cloudformation-templates/CovidLakeStack.template.json s3://covid19-lake/cfn/CovidLakeStack.template.json; \
-	awslocal s3 sync ./covid19-lake-data/ s3://covid19-lake/; \
-	awslocal cloudformation create-stack --stack-name covid-lake-stack --template-url http://s3.localhost.localstack.cloud:4566/covid19-lake/cfn/CovidLakeStack.template.json
+	lstk aws s3 mb s3://covid19-lake; \
+	lstk aws s3 cp cloudformation-templates/CovidLakeStack.template.json s3://covid19-lake/cfn/CovidLakeStack.template.json; \
+	lstk aws s3 sync ./covid19-lake-data/ s3://covid19-lake/; \
+	lstk aws cloudformation create-stack --stack-name covid-lake-stack --template-url http://s3.localhost.localstack.cloud:4566/covid19-lake/cfn/CovidLakeStack.template.json
 	@counter=0; \
 	while [ $$counter -lt 30 ]; do \
-		status=$$(awslocal cloudformation describe-stacks --stack-name covid-lake-stack | grep StackStatus | cut -d'"' -f4); \
+		status=$$(lstk aws cloudformation describe-stacks --stack-name covid-lake-stack | grep StackStatus | cut -d'"' -f4); \
 		echo "Attempt $$counter: Stack status: $$status"; \
 		if [ "$$status" = "CREATE_COMPLETE" ]; then \
 			echo "Stack creation completed successfully!"; \
@@ -39,26 +38,25 @@ deploy:		## Setup the architecture
 
 test:		## Run the tests
 	@echo "Installing dependencies..."
-	@pip install -r tests/requirements.txt
+	@pip3 install -r tests/requirements.txt
 	@echo "Running tests..."
-	pytest -s -v --disable-warnings tests/
+	python3 -m pytest -s -v --disable-warnings tests/
 	@echo "All tests completed successfully."
 
-start:		## Start LocalStack
+start:		## Start LocalStack (blocks until ready; image tag configured in .lstk/config.toml)
 	@echo "Starting LocalStack..."
 	@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
-	@LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) IMAGE_NAME=localstack/localstack-pro:latest-bigdata localstack start -d
+	@LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) lstk start
 	@echo "LocalStack started successfully."
 
 stop:		## Stop the Running LocalStack container
 	@echo "Stopping LocalStack..."
-	localstack stop
+	lstk stop
 
-ready:		## Make sure the LocalStack container is up
-	@echo Waiting on the LocalStack container...
-	@localstack wait -t 30 && echo LocalStack is ready to use! || (echo Gave up waiting on LocalStack, exiting. && exit 1)
+ready:		## Confirm LocalStack is ready (lstk start already waits, so this just reports status)
+	@lstk status
 
 logs:     ## Save the LocalStack logs in a separate file
-	@localstack logs > logs.txt
+	@lstk logs > logs.txt
 
 .PHONY: usage install run start stop ready logs

--- a/readme.md
+++ b/readme.md
@@ -34,8 +34,8 @@ The following diagram shows the architecture that this sample application builds
 ## Prerequisites
 
 - A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
-- [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli).
-- [AWS CLI](https://docs.localstack.cloud/user-guide/integrations/aws-cli/) with the [`awslocal` wrapper](https://docs.localstack.cloud/user-guide/integrations/aws-cli/#localstack-aws-cli-awslocal)
+- [`lstk` CLI](https://docs.localstack.cloud/aws/tooling/lstk/).
+- [AWS CLI](https://docs.localstack.cloud/user-guide/integrations/aws-cli/) with the [`lstk aws` proxy](https://docs.localstack.cloud/aws/tooling/lstk/)
 - [`make`](https://www.gnu.org/software/make/) (**optional**, but recommended for running the sample application)
 
 > [!NOTE]
@@ -43,7 +43,7 @@ The following diagram shows the architecture that this sample application builds
 > ```shell
 > docker pull localstack/localstack-pro:latest-bigdata
 > ```
-> Start the container with `IMAGE_NAME=localstack/localstack-pro:latest-bigdata` configuration variable to use the pre-installed dependencies.
+> This repo's `.lstk/config.toml` already configures `lstk start` to use this image variant, so no extra flags are needed.
 
 ## Installation
 
@@ -65,11 +65,10 @@ No additional installation steps are required as the sample uses CloudFormation 
 
 ## Deployment
 
-Start LocalStack with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
+Start LocalStack:
 
 ```shell
-localstack auth set-token <LOCALSTACK_AUTH_TOKEN>
-IMAGE_NAME=localstack/localstack-pro:latest-bigdata localstack start
+lstk start
 ```
 
 To deploy the sample application infrastructure, run the following command:
@@ -83,21 +82,21 @@ Alternatively, you can deploy manually step-by-step.
 ### Create S3 bucket and upload data
 
 ```shell
-awslocal s3 mb s3://covid19-lake
-awslocal s3 cp cloudformation-templates/CovidLakeStack.template.json s3://covid19-lake/cfn/CovidLakeStack.template.json
-awslocal s3 sync ./covid19-lake-data/ s3://covid19-lake/
+lstk aws s3 mb s3://covid19-lake
+lstk aws s3 cp cloudformation-templates/CovidLakeStack.template.json s3://covid19-lake/cfn/CovidLakeStack.template.json
+lstk aws s3 sync ./covid19-lake-data/ s3://covid19-lake/
 ```
 
 ### Deploy CloudFormation stack
 
 ```shell
-awslocal cloudformation create-stack --stack-name covid-lake-stack --template-url https://covid19-lake.s3.us-east-2.amazonaws.com/cfn/CovidLakeStack.template.json
+lstk aws cloudformation create-stack --stack-name covid-lake-stack --template-url https://covid19-lake.s3.us-east-2.amazonaws.com/cfn/CovidLakeStack.template.json
 ```
 
 ### Verify deployment
 
 ```shell
-awslocal cloudformation describe-stacks --stack-name covid-lake-stack | grep StackStatus
+lstk aws cloudformation describe-stacks --stack-name covid-lake-stack | grep StackStatus
 ```
 
 Wait for `CREATE_COMPLETE` status before proceeding.

--- a/tests/test_infra.py
+++ b/tests/test_infra.py
@@ -121,19 +121,30 @@ class TestAthenaQueries:
 
                 if state == 'SUCCEEDED':
                     results = athena_client.get_query_results(QueryExecutionId=query_execution_id)
-                    if not results['ResultSet']['Rows']:
+                    all_rows = results['ResultSet']['Rows']
+                    if not all_rows:
                         print(f"Query {query_execution_id} returned no rows at all.")
                         return pd.DataFrame()
-                    if len(results['ResultSet']['Rows']) == 1 and \
-                       all(not item.get('VarCharValue', '').strip() for item in results['ResultSet']['Rows'][0]['Data']):
-                        print(f"Query {query_execution_id} returned only an empty header row.")
-                        return pd.DataFrame()
-                    if len(results['ResultSet']['Rows']) <= 1:
-                         print(f"Query {query_execution_id} returned no data rows (only header).")
-                         return pd.DataFrame()
 
                     columns = [col['Label'] for col in results['ResultSet']['ResultSetMetadata']['ColumnInfo']]
-                    rows = [[item.get('VarCharValue', None) for item in row['Data']] for row in results['ResultSet']['Rows'][1:]]
+
+                    # SHOW/DESCRIBE-style utility statements return their data directly with
+                    # no header row, unlike SELECT queries where row 0 is always a header.
+                    is_utility_statement = query.strip().upper().startswith(('SHOW ', 'DESCRIBE '))
+                    if is_utility_statement:
+                        data_rows = all_rows
+                    else:
+                        if len(all_rows) == 1 and \
+                           all(not item.get('VarCharValue', '').strip() for item in all_rows[0]['Data']):
+                            print(f"Query {query_execution_id} returned only an empty header row.")
+                            return pd.DataFrame()
+                        data_rows = all_rows[1:]
+
+                    if not data_rows:
+                        print(f"Query {query_execution_id} returned no data rows (only header).")
+                        return pd.DataFrame()
+
+                    rows = [[item.get('VarCharValue', None) for item in row['Data']] for row in data_rows]
                     return pd.DataFrame(rows, columns=columns)
                 else:
                     query_status_response = athena_client.get_query_execution(QueryExecutionId=query_execution_id)
@@ -277,10 +288,24 @@ class TestAthenaQueries:
         except Exception as e:
             pytest.fail(f"Glue check failed for {self.DATABASE_NAME}.{table_name_param} even after readiness fixture: {str(e)}")
 
-        query = f"SHOW COLUMNS IN {table_name_param}"
+        # SHOW COLUMNS returns no rows against LocalStack's Athena implementation, so
+        # introspect the schema via a SELECT's ResultSetMetadata instead, which is
+        # always populated correctly regardless of how many rows come back.
+        query = f"SELECT * FROM {table_name_param} LIMIT 1"
         try:
-            results_df = self.execute_query_and_get_results(athena_client, query, output_location)
-            assert not results_df.empty, f"No columns found by Athena for table {self.DATABASE_NAME}.{table_name_param}"
-            print(f"Athena SHOW COLUMNS for {self.DATABASE_NAME}.{table_name_param}: {results_df.iloc[:, 0].tolist()}")
+            response = athena_client.start_query_execution(
+                QueryString=query,
+                QueryExecutionContext={'Database': self.DATABASE_NAME},
+                ResultConfiguration={'OutputLocation': output_location}
+            )
+            query_execution_id = response['QueryExecutionId']
+            state = self.wait_for_query_completion(athena_client, query_execution_id)
+            assert state == 'SUCCEEDED', f"Query {query_execution_id} did not succeed: {state}"
+            results = athena_client.get_query_results(QueryExecutionId=query_execution_id)
+            columns = [col['Label'] for col in results['ResultSet']['ResultSetMetadata']['ColumnInfo']]
+            assert columns, f"No columns found by Athena for table {self.DATABASE_NAME}.{table_name_param}"
+            print(f"Athena schema for {self.DATABASE_NAME}.{table_name_param}: {columns}")
+        except AssertionError:
+            raise
         except Exception as e:
-            pytest.fail(f"Athena SHOW COLUMNS for {self.DATABASE_NAME}.{table_name_param} failed: {str(e)}")
+            pytest.fail(f"Athena schema check for {self.DATABASE_NAME}.{table_name_param} failed: {str(e)}")


### PR DESCRIPTION
## Summary
- Replace the legacy `localstack` CLI (`start`/`stop`/`wait`/`logs`) and the `LocalStack/setup-localstack` GitHub Action with `lstk` across the Makefile and CI
- The `latest-bigdata` image tag (previously passed via `IMAGE_NAME`) is now configured once in `.lstk/config.toml`, which `lstk start` picks up automatically
- Update to Python 3
- Fix a test failure — `execute_query_and_get_results()` incorrectly dropped the first result row assuming a SELECT-style header row, which silently discarded the first entry of any `SHOW`-style query result.
